### PR TITLE
Update nethserver-collabora-conf to use rh-php72

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -43,11 +43,11 @@ if [[ -n `config getprop loolwsd VirtualHost` ]]; then
   #Configure Nextcloud
   if [[ -x "/usr/share/nextcloud/occ" ]]; then
 
-    sudo -u apache scl enable rh-php71 "/usr/share/nextcloud/occ app:install richdocuments"
+    sudo -u apache scl enable rh-php72 "/usr/share/nextcloud/occ app:install richdocuments"
 
-    sudo -u apache scl enable rh-php71 "/usr/share/nextcloud/occ config:app:set richdocuments wopi_url --value=https:\/\/`config getprop loolwsd VirtualHost`"
+    sudo -u apache scl enable rh-php72 "/usr/share/nextcloud/occ config:app:set richdocuments wopi_url --value=https:\/\/`config getprop loolwsd VirtualHost`"
 
-    sudo -u apache scl enable rh-php71 "/usr/share/nextcloud/occ app:enable richdocuments"
+    sudo -u apache scl enable rh-php72 "/usr/share/nextcloud/occ app:enable richdocuments"
   fi
 
 fi


### PR DESCRIPTION
NethServer/dev#6035

rh-php71 is replaced with rh-php72 in nethserver-collabora-conf to work with Nextcloud that installs rh-php72 now.