### PR TITLE
Fixes errors when running in non-interactive shells

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -31,22 +31,22 @@ loolconfig set net.proto IPv4
 AllowWopiHosts=`hostname`
 
 #Nextcloud virtualhost
-if [[ -n `config getprop nextcloud VirtualHost` ]];then AllowWopiHosts+="|`config getprop nextcloud VirtualHost`";fi
+if [[ -n `/sbin/e-smith/config getprop nextcloud VirtualHost` ]];then AllowWopiHosts+="|`/sbin/e-smith/config getprop nextcloud VirtualHost`";fi
 
 #Additional external host
-if [[ -n `config getprop loolwsd AllowWopiHost` ]];then AllowWopiHosts+="|`config getprop loolwsd AllowWopiHost`";fi
+if [[ -n `/sbin/e-smith/config getprop loolwsd AllowWopiHost` ]];then AllowWopiHosts+="|`/sbin/e-smith/config getprop loolwsd AllowWopiHost`";fi
 
 loolconfig set storage.wopi.host "$AllowWopiHosts"
 
 
-if [[ -n `config getprop loolwsd VirtualHost` ]]; then
+if [[ -n `/sbin/e-smith/config getprop loolwsd VirtualHost` ]]; then
 
   #Configure Nethserver-Nextcloud
   if [[ -x "/usr/local/sbin/occ" ]]; then
 
     /usr/local/sbin/occ app:install richdocuments
 
-    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://`config getprop loolwsd VirtualHost`
+    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://`/sbin/e-smith/config getprop loolwsd VirtualHost`
 
     /usr/local/sbin/occ app:enable richdocuments
   fi


### PR DESCRIPTION
When the `nethserver-collabora-update` event is run during an upgrade (hence non-interactive), it seems the `config` command is not found inside the path, resulting in a non-working instance.

With the proposed fixes, during upgrade the command should work as expected and the upgrade shouldn't be broken anymore.

