### PR TITLE
Enhancement based on marVnl work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,20 +9,38 @@ This package provide Nethserver integration of `Collabora Online Development Edi
 First configuration
 ===================
 
-Collabora Online requires a dedicated virtual host and it's only accessible from HTTPS with a valid certificate.
+Collabora Online requires a dedicated virtual host and it's only accessible from HTTPS.  
+On installation the (default) virtual host ``collabora.server_domain`` is created, an other virtual host can be set by executing:
 
-To configure Collobora Online, execute: ::
+::
 
-  config setprop loolwsd VirtualHost collabora.yourdomain.com
+  config setprop loolwsd VirtualHost loolwsd.yourdomain.com 
   signal-event nethserver-collabora-update
 
-After virtual host configuration, obtain a valid HTTPS certificate via Let's encrypt from ``Server certificate`` section of Server Manager interface.
+It is recommended to obtain a valid HTTPS certificate for the virtual host;
+this can be done via Let's encrypt from ``Server certificate`` section of Server Manager interface.
+
+note: ::
+
+  If no valid certificate is present open the virtual host in your web-browser to add an exception for the certificate.
 
 The package does the following:
 
-* Add server FQDN and Nextcloud custom virtual host, if present, to the trusted domains allowed to access to Collabora Online
-* If nethserver-nextcloud is installed, and the prop ``VirtualHost`` is set, nethserver-collabora-event will automatically enable
-  Nextcloud for use Collabora Online.
+* Create a virtual host for collabora.
+* If nethserver-nextcloud is installed on the same server:
+
+  * Install and configure richdocuments-app
+  * Add server FQDN and Nextcloud custom virtual host, if present, to the trusted domains allowed to access to Collabora Online
+
+
+If your instance of Nextcloud is not installed in the same server of Collabora Online,
+you must set the host name of Nextcloud in the prop ``AllowWopiHost``: ::
+
+  config setprop loolwsd AllowWopiHost nextcloud-office.yourdomain.com
+  signal-event nethserver-collabora-update
+
+Then manually install and configure the Nextcloud `richdocuments app <https://github.com/nextcloud/richdocuments#nextcloud-app>`_.
+
 
 Database
 ========
@@ -42,13 +60,17 @@ examples: ::
   config show loolwsd
   loolwsd=service
     AllowWopiHost=nextcloud-office.yourdomain.com
-    VirtualHost=loolwsd-dev.nethserver.net
+    VirtualHost=loolwsd.yourdomain.com
     status=enable
 
 
 Admin user
 ==========
 
-After installation, admin dashboard can be enable with ``loolconfig set-admin-password`` and accessible at: ::
+After installation, admin dashboard can be enabled with : ::
+
+  loolconfig set-admin-password 
+  
+And is accessible at: ::
 
   https://collabora.yourdomain.com/loleaflet/dist/admin/admin.html

--- a/README.rst
+++ b/README.rst
@@ -74,3 +74,15 @@ After installation, admin dashboard can be enabled with : ::
 And is accessible at: ::
 
   https://collabora.yourdomain.com/loleaflet/dist/admin/admin.html
+
+
+Collabora repository
+====================
+
+Update from CODE repository: ::
+
+  yum install yum-utils
+  yum-config-manager --add-repo https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-centos7
+  wget https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-centos7/repodata/repomd.xml.key && rpm --import repomd.xml.key
+  yum update -y --enablerepo=collaboraoffice.com_repos_CollaboraOnline_CODE-centos7
+

--- a/createlinks
+++ b/createlinks
@@ -1,4 +1,23 @@
 #!/usr/bin/perl -w
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+# 
+# This script is part of NethServer.
+# 
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+# 
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
 
 use esmith::Build::CreateLinks qw(:all);
 

--- a/createlinks
+++ b/createlinks
@@ -51,3 +51,9 @@ event_actions($event, qw(
              nethserver-collabora-conf 70
              nethserver-collabora-set-wopi-url 91
 ));
+
+$event = 'nethserver-nextcloud-save';
+event_actions($event, qw(
+             nethserver-collabora-conf 70
+             nethserver-collabora-set-wopi-url 91
+));

--- a/createlinks
+++ b/createlinks
@@ -32,6 +32,7 @@ event_actions($event, qw(
              initialize-default-databases 00
              nethserver-collabora-conf 20
              nethserver-collabora-set-wopi-url 91
+             nethserver-collabora-restart-loolwsd 99
 ));
 
 event_templates($event, qw(
@@ -42,7 +43,6 @@ event_templates($event, qw(
 event_services($event, qw(
                httpd reload
                dnsmasq restart
-               loolwsd restart
 ));
 
 

--- a/createlinks
+++ b/createlinks
@@ -21,15 +21,22 @@
 
 use esmith::Build::CreateLinks qw(:all);
 
-my $event = 'nethserver-collabora-update';
+$event = 'certificate-update';
+event_actions($event, qw(
+             nethserver-collabora-set-wopi-url 91
+));
 
+
+my $event = 'nethserver-collabora-update';
 event_actions($event, qw(
              initialize-default-databases 00
              nethserver-collabora-conf 20
+             nethserver-collabora-set-wopi-url 91
 ));
 
 event_templates($event, qw(
   /etc/httpd/conf.d/zz_collabora.conf
+  /etc/hosts
 ));
 
 event_services($event, qw(
@@ -37,7 +44,9 @@ event_services($event, qw(
                loolwsd restart
 ));
 
+
 $event = 'nethserver-nextcloud-update';
 event_actions($event, qw(
              nethserver-collabora-conf 70
+             nethserver-collabora-set-wopi-url 91
 ));

--- a/createlinks
+++ b/createlinks
@@ -41,6 +41,7 @@ event_templates($event, qw(
 
 event_services($event, qw(
                httpd reload
+               dnsmasq restart
                loolwsd restart
 ));
 

--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -20,23 +20,27 @@
 #!/bin/bash
 
 # Disable ssl
-loolconfig set ssl.enable  false
-loolconfig set ssl.termination  true
-loolconfig set net.listen loopback
-loolconfig set net.proto IPv4
+/usr/bin/loolconfig set ssl.enable  false
+/usr/bin/loolconfig set ssl.termination  true
+/usr/bin/loolconfig set net.listen loopback
+/usr/bin/loolconfig set net.proto IPv4
 
 
 #Generate a list of hosts that can access to the wopi storage
 #Server FQDN
-AllowWopiHosts=`hostname`
+AllowWopiHosts=`/usr/bin/hostname`
 
 #Nextcloud virtualhost
-if [[ -n `/sbin/e-smith/config getprop nextcloud VirtualHost` ]];then AllowWopiHosts+="|`/sbin/e-smith/config getprop nextcloud VirtualHost`";fi
+if [[ -n `/sbin/e-smith/config getprop nextcloud VirtualHost` ]]; then 
+    AllowWopiHosts+="|`/sbin/e-smith/config getprop nextcloud VirtualHost`"
+fi
 
 #Additional external host
-if [[ -n `/sbin/e-smith/config getprop loolwsd AllowWopiHost` ]];then AllowWopiHosts+="|`/sbin/e-smith/config getprop loolwsd AllowWopiHost`";fi
+if [[ -n `/sbin/e-smith/config getprop loolwsd AllowWopiHost` ]]; then 
+    AllowWopiHosts+="|`/sbin/e-smith/config getprop loolwsd AllowWopiHost`"
+fi
 
-loolconfig set storage.wopi.host "$AllowWopiHosts"
+/usr/bin/loolconfig set storage.wopi.host "$AllowWopiHosts"
 
 
 if [[ -n `/sbin/e-smith/config getprop loolwsd VirtualHost` ]]; then

--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright (C) 2019 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
@@ -17,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NethServer.  If not, see COPYING.
 #
-#!/bin/bash
+
 
 # Disable ssl
 /usr/bin/loolconfig set ssl.enable  false

--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -42,17 +42,8 @@ fi
 
 /usr/bin/loolconfig set storage.wopi.host "$AllowWopiHosts"
 
-
-if [[ -n `/sbin/e-smith/config getprop loolwsd VirtualHost` ]]; then
-    WopiUrl=`config getprop loolwsd VirtualHost`
-else
-    WopiUrl=collabora.`config get DomainName`
-fi
-
-#Configure Nethserver-Nextcloud
+#Install Nethserver-Nextcloud app
 if [[ -x "/usr/local/sbin/occ" ]]; then
     /usr/local/sbin/occ app:install richdocuments
     /usr/local/sbin/occ app:enable richdocuments
-    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://$WopiUrl
-    /usr/local/sbin/occ richdocuments:activate-config
 fi

--- a/root/etc/e-smith/events/actions/nethserver-collabora-conf
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-conf
@@ -44,15 +44,15 @@ fi
 
 
 if [[ -n `/sbin/e-smith/config getprop loolwsd VirtualHost` ]]; then
+    WopiUrl=`config getprop loolwsd VirtualHost`
+else
+    WopiUrl=collabora.`config get DomainName`
+fi
 
-  #Configure Nethserver-Nextcloud
-  if [[ -x "/usr/local/sbin/occ" ]]; then
-
+#Configure Nethserver-Nextcloud
+if [[ -x "/usr/local/sbin/occ" ]]; then
     /usr/local/sbin/occ app:install richdocuments
-
-    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://`/sbin/e-smith/config getprop loolwsd VirtualHost`
-
     /usr/local/sbin/occ app:enable richdocuments
-  fi
-
+    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://$WopiUrl
+    /usr/local/sbin/occ richdocuments:activate-config
 fi

--- a/root/etc/e-smith/events/actions/nethserver-collabora-restart-loolwsd
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-restart-loolwsd
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# must be the last action, we restart loolwsd
+
+/usr/bin/systemctl restart loolwsd

--- a/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
@@ -31,10 +31,10 @@ if [[ -x "/usr/local/sbin/occ" ]]; then
     /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://$WopiUrl
     
     /usr/bin/curl https://$WopiUrl > /dev/null 2>&1
-    if [ $? -eq 60 ]; then
-        /usr/local/sbin/occ config:app:set richdocuments disable_certificate_verification --value=yes
-    else
+    if [ $? -eq 0 ]; then
         /usr/local/sbin/occ config:app:set richdocuments disable_certificate_verification --value=''
+    else
+        /usr/local/sbin/occ config:app:set richdocuments disable_certificate_verification --value=yes
     fi
     
     /usr/local/sbin/occ richdocuments:activate-config

--- a/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+#!/bin/bash
+
+#Configure WopiUrl for Nethserver-Nextcloud
+if [[ -x "/usr/local/sbin/occ" ]]; then
+
+    if [[ -n `/sbin/e-smith/config getprop loolwsd VirtualHost` ]]; then
+        WopiUrl=`/sbin/e-smith/config getprop loolwsd VirtualHost`
+    else
+        WopiUrl=collabora.`/sbin/e-smith/config get DomainName`
+    fi
+
+    /usr/local/sbin/occ config:app:set richdocuments wopi_url --value=https://$WopiUrl
+    
+    /usr/bin/curl https://$WopiUrl > /dev/null 2>&1
+    if [ $? -eq 60 ]; then
+        /usr/local/sbin/occ config:app:set richdocuments disable_certificate_verification --value=yes
+    else
+        /usr/local/sbin/occ config:app:set richdocuments disable_certificate_verification --value=''
+    fi
+    
+    /usr/local/sbin/occ richdocuments:activate-config
+    
+fi

--- a/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
+++ b/root/etc/e-smith/events/actions/nethserver-collabora-set-wopi-url
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright (C) 2021 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
@@ -17,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NethServer.  If not, see COPYING.
 #
-#!/bin/bash
+
 
 #Configure WopiUrl for Nethserver-Nextcloud
 if [[ -x "/usr/local/sbin/occ" ]]; then

--- a/root/etc/e-smith/templates/etc/hosts/10hosts_self_collabora
+++ b/root/etc/e-smith/templates/etc/hosts/10hosts_self_collabora
@@ -1,0 +1,11 @@
+{
+    #
+    # 10hosts_self_collabora
+    #
+
+    if (($loolwsd{'VirtualHost'} || '') eq '') {
+        push @hostnames, "collabora.${DomainName}";
+    }
+
+    '';
+}

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
@@ -4,6 +4,19 @@
     if ($VHost ne '') {
         $OUT .= <<EOF
 
+<VirtualHost *:80>
+    IncludeOptional conf.d/default-virtualhost.inc
+</VirtualHost>
+
+
+<VirtualHost *:80>
+   ServerName $VHost
+   RedirectMatch 301 ^(?!/.well-known/acme-challenge/).* https://$VHost
+   RewriteEngine On
+   RewriteCond %\{HTTPS\} !=on
+   RewriteRule (.*) https://%\{SERVER_NAME\}\$1 [R,L]
+</VirtualHost>
+
 
 <VirtualHost *:443>
     ServerName $VHost

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
@@ -1,5 +1,5 @@
 {
-  my $domain = $loolwsd{'VirtualHost'} || '';
+  my $domain = $loolwsd{'VirtualHost'} || "collabora." . $DomainName;
 
   if ($domain ne '') {
     $OUT .= "<VirtualHost *:443>\n";

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zz_collabora.conf/10base
@@ -1,40 +1,46 @@
 {
-  my $domain = $loolwsd{'VirtualHost'} || "collabora." . $DomainName;
+    my $VHost = $loolwsd{'VirtualHost'} || "collabora." . $DomainName;
 
-  if ($domain ne '') {
-    $OUT .= "<VirtualHost *:443>\n";
-    $OUT .= "  ServerName $domain\n";
+    if ($VHost ne '') {
+        $OUT .= <<EOF
 
-    $OUT .= "  SSLEngine on\n";
 
-    $OUT .= "  # Encoded slashes need to be allowed\n";
-    $OUT .= "  AllowEncodedSlashes NoDecode\n";
+<VirtualHost *:443>
+    ServerName $VHost
 
-    $OUT .= "  # keep the host\n";
-    $OUT .= "  ProxyPreserveHost On\n";
+    SSLEngine on
 
-    $OUT .= "  # static html, js, images, etc. served from loolwsd\n";
-    $OUT .= "  # loleaflet is the client part of LibreOffice Online\n";
-    $OUT .= "  ProxyPass           /loleaflet http://127.0.0.1:9980/loleaflet retry=0\n";
-    $OUT .= "  ProxyPassReverse    /loleaflet http://127.0.0.1:9980/loleaflet\n";
+    # Encoded slashes need to be allowed
+    AllowEncodedSlashes NoDecode
 
-    $OUT .= "  # WOPI discovery URL\n";
-    $OUT .= "  ProxyPass           /hosting/discovery http://127.0.0.1:9980/hosting/discovery retry=0\n";
-    $OUT .= "  ProxyPassReverse    /hosting/discovery http://127.0.0.1:9980/hosting/discovery\n";
+    # keep the host
+    ProxyPreserveHost On
 
-    $OUT .= "  # Main websocket\n";
-    $OUT .= "  ProxyPassMatch \"/lool/(.*)/ws\$\" ws://127.0.0.1:9980/lool/\$1/ws nocanon\n";
+    # static html, js, images, etc. served from loolwsd
+    # loleaflet is the client part of LibreOffice Online
+    ProxyPass           /loleaflet http://127.0.0.1:9980/loleaflet retry=0
+    ProxyPassReverse    /loleaflet http://127.0.0.1:9980/loleaflet
 
-    $OUT .= "  # Admin Console websocket\n";
-    $OUT .= "  ProxyPass   /lool/adminws ws://127.0.0.1:9980/lool/adminws\n";
+    # WOPI discovery URL
+    ProxyPass           /hosting/discovery http://127.0.0.1:9980/hosting/discovery retry=0
+    ProxyPassReverse    /hosting/discovery http://127.0.0.1:9980/hosting/discovery
 
-    $OUT .= "  # Download as, Fullscreen presentation and Image upload operations\n";
-    $OUT .= "  ProxyPass           /lool http://127.0.0.1:9980/lool\n";
-    $OUT .= "  ProxyPassReverse    /lool http://127.0.0.1:9980/lool\n";
+    # Main websocket
+    ProxyPassMatch \"/lool/(.*)/ws\$\" ws://127.0.0.1:9980/lool/\$1/ws nocanon
 
-    $OUT .= "  # Endpoint with information about availability of various features\n";
-    $OUT .= "  ProxyPass           /hosting/capabilities http://127.0.0.1:9980/hosting/capabilities retry=0\n";
-    $OUT .= "  ProxyPassReverse    /hosting/capabilities http://127.0.0.1:9980/hosting/capabilities\n";
-    $OUT .= "</VirtualHost>\n";
-  }
+    # Admin Console websocket
+    ProxyPass   /lool/adminws ws://127.0.0.1:9980/lool/adminws
+
+    # Download as, Fullscreen presentation and Image upload operations
+    ProxyPass           /lool http://127.0.0.1:9980/lool
+    ProxyPassReverse    /lool http://127.0.0.1:9980/lool
+
+    # Endpoint with information about availability of various features
+    ProxyPass           /hosting/capabilities http://127.0.0.1:9980/hosting/capabilities retry=0
+    ProxyPassReverse    /hosting/capabilities http://127.0.0.1:9980/hosting/capabilities
+</VirtualHost>
+
+EOF
+
+    }
 }


### PR DESCRIPTION
Continue the work of markVnl of the PR https://github.com/NethServer/nethserver-collabora/pull/8


I have an issue the service loolwsd must be started at the end

The issue : https://github.com/NethServer/dev/issues/6437


Since the loolwsd is restarting we can find this in messages log

```
 Apr 15 20:33:11 ns7loc11 esmith::event[747]: Failed to activate any config changes
Apr 15 20:33:11 ns7loc11 esmith::event[747]: Server error: `GET https://collabora.nethservertest.org/hosting/discovery` resulted in a
 `503 Service Unavailable` response:
Apr 15 20:33:11 ns7loc11 esmith::event[747]: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
Apr 15 20:33:11 ns7loc11 esmith::event[747]: <html><head>
Apr 15 20:33:11 ns7loc11 esmith::event[747]: <title>503 Service Unavailable</title>
Apr 15 20:33:11 ns7loc11 esmith::event[747]: </head><body>
Apr 15 20:33:11 ns7loc11 esmith::event[747]: <h1 (truncated...)
Apr 15 20:33:11 ns7loc11 esmith::event[747]: 
```